### PR TITLE
Added support for modkits in modes

### DIFF
--- a/DLSv2/Core/DLSModel.cs
+++ b/DLSv2/Core/DLSModel.cs
@@ -5,6 +5,8 @@ using System.Linq;
 
 namespace DLSv2.Core
 {
+    using Utils;
+
     [XmlRoot("Model")]
     public class DLSModel
     {
@@ -102,6 +104,10 @@ namespace DLSv2.Core
         [XmlArray("Extras", IsNullable = true)]
         [XmlArrayItem("Extra")]
         public List<Extra> Extra = new List<Extra>();
+
+        [XmlArray("ModKits", IsNullable = true)]
+        [XmlArrayItem("Kit")]
+        public List<ModKit> ModKits = new List<ModKit>();
 
         [XmlElement("SirenSettings", IsNullable = true)]
         public SirenSetting SirenSettings = new SirenSetting();
@@ -221,6 +227,15 @@ namespace DLSv2.Core
         public string Enabled;
     }
 
+    public class ModKit
+    {
+        [XmlAttribute("Type")]
+        public ModKitType Type;
+
+        [XmlAttribute("Index")]
+        public int Index;
+    }
+
     public class SequenceItem
     {
         [XmlAttribute("ID")]
@@ -257,7 +272,7 @@ namespace DLSv2.Core
         [XmlText]
         public string ModesRaw
         {
-            get => ModesRaw;
+            get => string.Join(",", Modes);
             set
             {
                 Modes = value.Split(',').Select(s => s.Trim()).ToList();

--- a/DLSv2/Core/Lights/ModeManager.cs
+++ b/DLSv2/Core/Lights/ModeManager.cs
@@ -96,6 +96,11 @@ namespace DLSv2.Core.Lights
                 foreach (Extra extra in mode.Extra.OrderByDescending(e => e.Enabled))
                    if (vehicle.HasExtra(extra.ID)) vehicle.SetExtra(extra.ID, extra.Enabled.ToBoolean());
 
+                // Sets modkits for the specific mode
+                foreach (ModKit kit in mode.ModKits)
+                    if (vehicle.HasModkitMod(kit.Type) && vehicle.GetModkitModCount(kit.Type) > kit.Index)
+                        vehicle.SetModkitModIndex(kit.Type, kit.Index);
+
                 // Sets the yield setting
                 if (mode.Yield.Enabled) shouldYield = true;
             }

--- a/DLSv2/DLSv2.csproj
+++ b/DLSv2/DLSv2.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Utils\Extras.cs" />
     <Compile Include="Utils\Loaders.cs" />
     <Compile Include="Utils\Log.cs" />
+    <Compile Include="Utils\Modkits.cs" />
     <Compile Include="Utils\Settings.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DLSv2/Utils/Modkits.cs
+++ b/DLSv2/Utils/Modkits.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Rage;
+using Rage.Native;
+
+namespace DLSv2.Utils
+{
+    internal static class Modkits
+    {
+        public static bool HasModKits(this Vehicle vehicle) => NativeFunction.Natives.GET_NUM_MOD_KITS<int>(vehicle) > 0;
+
+        public static bool HasModkitMod(this Vehicle vehicle, ModKitType modType) => GetModkitModCount(vehicle, modType) > 0;
+
+        public static int GetModkitModCount(this Vehicle vehicle, ModKitType modType)
+        {
+            vehicle.Mods.InstallModKit();
+            return NativeFunction.Natives.GET_NUM_VEHICLE_MODS<int>(vehicle, (int)modType);
+        }
+
+        public static int GetModkitModIndex(this Vehicle vehicle, ModKitType modType)
+        {
+            vehicle.Mods.InstallModKit();
+            return NativeFunction.Natives.GET_VEHICLE_MOD<int>(vehicle, (int)modType);
+        }
+
+        public static void SetModkitModIndex(this Vehicle vehicle, ModKitType modType, int value)
+        {
+            vehicle.Mods.InstallModKit();
+            NativeFunction.Natives.SET_VEHICLE_MOD(vehicle, (int)modType, value, false);
+        }
+    }
+
+    public enum ModKitType
+    {
+        NONE = -1,
+        VMT_SPOILER = 0,
+        VMT_BUMPER_F = 1,
+        VMT_BUMPER_R = 2,
+        VMT_SKIRT = 3,
+        VMT_EXHAUST = 4,
+        VMT_CHASSIS = 5,
+        VMT_GRILL = 6,
+        VMT_BONNET = 7,
+        VMT_WING_L = 8,
+        VMT_WING_R = 9,
+        VMT_ROOF = 10,
+        VMT_ENGINE = 11,
+        VMT_BRAKES = 12,
+        VMT_GEARBOX = 13,
+        VMT_HORN = 14,
+        VMT_SUSPENSION = 15,
+        VMT_ARMOUR = 16,
+        VMT_NITROUS = 17,
+        VMT_TURBO = 18,
+        VMT_SUBWOOFER = 19,
+        VMT_TYRE_SMOKE = 20,
+        VMT_HYDRAULICS = 21,
+        VMT_XENON_LIGHTS = 22,
+        VMT_WHEELS = 23,
+        VMT_WHEELS_REAR_OR_HYDRAULICS = 24,
+        VMT_PLTHOLDER = 25,
+        VMT_PLTVANITY = 26,
+        VMT_INTERIOR1 = 27,
+        VMT_INTERIOR2 = 28,
+        VMT_INTERIOR3 = 29,
+        VMT_INTERIOR4 = 30,
+        VMT_INTERIOR5 = 31,
+        VMT_SEATS = 32,
+        VMT_STEERING = 33,
+        VMT_KNOB = 34,
+        VMT_PLAQUE = 35,
+        VMT_ICE = 36,
+        VMT_TRUNK = 37,
+        VMT_HYDRO = 38,
+        VMT_ENGINEBAY1 = 39,
+        VMT_ENGINEBAY2 = 40,
+        VMT_ENGINEBAY3 = 41,
+        VMT_CHASSIS2 = 42,
+        VMT_CHASSIS3 = 43,
+        VMT_CHASSIS4 = 44,
+        VMT_CHASSIS5 = 45,
+        VMT_DOOR_L = 46,
+        VMT_DOOR_R = 47,
+        VMT_LIVERY_MOD = 48,
+        VMT_LIGHTBAR = 49,
+    }
+}


### PR DESCRIPTION
Added ModKits to XML format and implemented in ModeManager to apply modkits. Will need to consider modkits later when determining "default" state to turn modkits off as needed. 

Example of XML format: 


 ```xml
<Mode name="Stage 2">
	<SirenSettings>
	<!-- ... -->
	</SirenSettings>
	<ModKits>
		<Kit Type="VMT_ROOF" Index="1" />
	</ModKits>
</Mode>
```