### PR TITLE
Implement multiple ID support for SirenSetting Items and Sequencer Items

### DIFF
--- a/DLSv2/Core/DLSModel.cs
+++ b/DLSv2/Core/DLSModel.cs
@@ -158,25 +158,8 @@ namespace DLSv2.Core
                     {
                         int ID = int.Parse(id.Trim());
                         
-                        SirenEntry targetSiren = SirenSettings.Sirens.LastOrDefault(s => s.sirenIDs.Contains(ID));
-
-                        if (targetSiren == null)
-                        {
-                            targetSiren = new SirenEntry(ID)
-                            {
-                                Flashiness = new LightDetailEntry
-                                {
-                                    Sequence = new Sequencer(item.Sequence)
-                                }
-                            };
-                            SirenSettings.SirenList.Add(targetSiren);
-                        } else if (targetSiren.Flashiness == null) 
-                        {
-                            targetSiren.Flashiness = new LightDetailEntry() {  Sequence = new Sequencer(item.Sequence) };
-                        } else
-                        {
-                            targetSiren.Flashiness.Sequence = new Sequencer(item.Sequence);
-                        }
+                        SirenEntry siren = new SirenEntry(ID) { Flashiness = new LightDetailEntry { Sequence = new Sequencer(item.Sequence) } };
+                        SirenSettings.SirenList.Add(siren);
                     }
                 }
 

--- a/DLSv2/Core/DLSModel.cs
+++ b/DLSv2/Core/DLSModel.cs
@@ -136,30 +136,34 @@ namespace DLSv2.Core
                 {
                     if (SirenSettings == null) SirenSettings = new SirenSetting();
 
-                    // If siren ID string is a head/tail light sequencer, set and continue to next item 
-                    switch (item.ID)
-                    {
-                        case "leftHeadLight":
-                            SirenSettings.LeftHeadLightSequencer = new SequencerWrapper(item.Sequence);
-                            continue;
-                        case "rightHeadLight":
-                            SirenSettings.RightHeadLightSequencer = new SequencerWrapper(item.Sequence);
-                            continue;
-                        case "leftTailLight":
-                            SirenSettings.LeftTailLightSequencer = new SequencerWrapper(item.Sequence);
-                            continue;
-                        case "rightTailLight":
-                            SirenSettings.RightTailLightSequencer = new SequencerWrapper(item.Sequence);
-                            continue;
-                    }
-
                     // Parse siren ID into one or more integers
-                    foreach (string id in item.ID.Split(','))
+                    foreach (string id in item.IDs.Split(','))
                     {
-                        int ID = int.Parse(id.Trim());
-                        
-                        SirenEntry siren = new SirenEntry(ID) { Flashiness = new LightDetailEntry { Sequence = new Sequencer(item.Sequence) } };
-                        SirenSettings.SirenList.Add(siren);
+                        // If siren ID string is a head/tail light sequencer, set and continue to next item 
+                        switch (id)
+                        {
+                            case "leftHeadLight":
+                                SirenSettings.LeftHeadLightSequencer = new SequencerWrapper(item.Sequence);
+                                continue;
+                            case "rightHeadLight":
+                                SirenSettings.RightHeadLightSequencer = new SequencerWrapper(item.Sequence);
+                                continue;
+                            case "leftTailLight":
+                                SirenSettings.LeftTailLightSequencer = new SequencerWrapper(item.Sequence);
+                                continue;
+                            case "rightTailLight":
+                                SirenSettings.RightTailLightSequencer = new SequencerWrapper(item.Sequence);
+                                continue;
+                        }
+
+                        if (int.TryParse(id.Trim(), out int ID))
+                        {
+                            SirenEntry siren = new SirenEntry(ID) { Flashiness = new LightDetailEntry { Sequence = new Sequencer(item.Sequence) } };
+                            SirenSettings.SirenList.Add(siren);
+                        } else
+                        {
+                            $"Mode {Name} siren id {id} is invalid".ToLog();
+                        }
                     }
                 }
 
@@ -257,7 +261,7 @@ namespace DLSv2.Core
     public class SequenceItem
     {
         [XmlAttribute("id")]
-        public string ID;
+        public string IDs;
 
         [XmlAttribute("sequence")]
         public string Sequence;

--- a/DLSv2/Core/Lights/ModeManager.cs
+++ b/DLSv2/Core/Lights/ModeManager.cs
@@ -78,7 +78,7 @@ namespace DLSv2.Core.Lights
                 }
             }
 
-            SirenApply.ApplySirenSettingsToEmergencyLighting(Mode.GetEmpty(vehicle).SirenSettings, eL);
+            SirenApply.ApplySirenSettingsToEmergencyLighting(managedVehicle.EmptyMode.SirenSettings, eL);
 
             bool shouldYield = false;
             var extras = new Dictionary<int, bool>();

--- a/DLSv2/Core/ManagedVehicle.cs
+++ b/DLSv2/Core/ManagedVehicle.cs
@@ -60,6 +60,8 @@ namespace DLSv2.Core
                 };
             }
 
+            EmptyMode = Mode.GetEmpty(vehicle);
+
             var temp = vehicle.IsSirenOn;
             vehicle.IsSirenOn = false;
             vehicle.IsSirenOn = temp;
@@ -83,6 +85,8 @@ namespace DLSv2.Core
         public Dictionary<string, (bool Status, int Index)> LightControlGroups = new Dictionary<string, (bool, int)>();
         public Dictionary<string, bool> StandaloneLightModes = new Dictionary<string, bool>();
         public List<string> ActiveLightModes = new List<string>();
+
+        public Mode EmptyMode;
 
         /// <summary>
         /// Sirens

--- a/DLSv2/Core/SirenApply.cs
+++ b/DLSv2/Core/SirenApply.cs
@@ -24,48 +24,50 @@ namespace DLSv2.Core
             els.RightTailLightSequenceRaw = setting.RightTailLightSequencer?.Sequencer?.Value ?? els.RightTailLightSequenceRaw;
             els.RightTailLightMultiples = setting.RightTailLightMultiples?.Value ?? els.RightTailLightMultiples;
 
-            foreach (SirenEntry siren in setting.Sirens)
+            foreach (SirenEntry entry in setting.Sirens)
             {
-                if (siren == null) continue;
+                if (entry == null) continue;
 
-                SirenEntry entry = siren;
-                EmergencyLight light = els.Lights[siren.ID - 1];
+                foreach (int id in entry.sirenIDs)
+                {
+                    EmergencyLight light = els.Lights[id - 1];
 
-                // Main light settings
-                light.Color = entry.LightColor ?? light.Color;
-                light.Intensity = entry.Intensity?.Value ?? light.Intensity;
-                light.LightGroup = entry.LightGroup?.Value ?? light.LightGroup;
-                light.Rotate = entry.Rotate?.Value ?? light.Rotate;
-                light.Scale = entry.Scale?.Value ?? light.Scale;
-                light.ScaleFactor = entry.ScaleFactor?.Value ?? light.ScaleFactor;
-                light.Flash = entry.Flash?.Value ?? light.Flash;
-                light.SpotLight = entry.SpotLight?.Value ?? light.SpotLight;
-                light.CastShadows = entry.CastShadows?.Value ?? light.CastShadows;
-                light.Light = entry.Light?.Value ?? light.Light;
+                    // Main light settings
+                    light.Color = entry.LightColor ?? light.Color;
+                    light.Intensity = entry.Intensity?.Value ?? light.Intensity;
+                    light.LightGroup = entry.LightGroup?.Value ?? light.LightGroup;
+                    light.Rotate = entry.Rotate?.Value ?? light.Rotate;
+                    light.Scale = entry.Scale?.Value ?? light.Scale;
+                    light.ScaleFactor = entry.ScaleFactor?.Value ?? light.ScaleFactor;
+                    light.Flash = entry.Flash?.Value ?? light.Flash;
+                    light.SpotLight = entry.SpotLight?.Value ?? light.SpotLight;
+                    light.CastShadows = entry.CastShadows?.Value ?? light.CastShadows;
+                    light.Light = entry.Light?.Value ?? light.Light;
 
-                // Corona settings
-                light.CoronaIntensity = entry.Corona.CoronaIntensity?.Value ?? light.CoronaIntensity;
-                light.CoronaSize = entry.Corona.CoronaSize?.Value ?? light.CoronaSize;
-                light.CoronaPull = entry.Corona.CoronaPull?.Value ?? light.CoronaPull;
-                light.CoronaFaceCamera = entry.Corona.CoronaFaceCamera?.Value ?? light.CoronaFaceCamera;
+                    // Corona settings
+                    light.CoronaIntensity = entry.Corona.CoronaIntensity?.Value ?? light.CoronaIntensity;
+                    light.CoronaSize = entry.Corona.CoronaSize?.Value ?? light.CoronaSize;
+                    light.CoronaPull = entry.Corona.CoronaPull?.Value ?? light.CoronaPull;
+                    light.CoronaFaceCamera = entry.Corona.CoronaFaceCamera?.Value ?? light.CoronaFaceCamera;
 
-                // Rotation settings
-                light.RotationDelta = entry.Rotation.DeltaDeg ?? light.RotationDelta;
-                light.RotationStart = entry.Rotation.StartDeg ?? light.RotationStart;
-                light.RotationSpeed = entry.Rotation.Speed?.Value ?? light.RotationSpeed;
-                light.RotationSequenceRaw = entry.Rotation.Sequence ?? light.RotationSequenceRaw;
-                light.RotationMultiples = entry.Rotation.Multiples?.Value ?? light.RotationMultiples;
-                light.RotationDirection = entry.Rotation.Direction?.Value ?? light.RotationDirection;
-                light.RotationSynchronizeToBpm = entry.Rotation.SyncToBPM?.Value ?? light.RotationSynchronizeToBpm;
+                    // Rotation settings
+                    light.RotationDelta = entry.Rotation.DeltaDeg ?? light.RotationDelta;
+                    light.RotationStart = entry.Rotation.StartDeg ?? light.RotationStart;
+                    light.RotationSpeed = entry.Rotation.Speed?.Value ?? light.RotationSpeed;
+                    light.RotationSequenceRaw = entry.Rotation.Sequence ?? light.RotationSequenceRaw;
+                    light.RotationMultiples = entry.Rotation.Multiples?.Value ?? light.RotationMultiples;
+                    light.RotationDirection = entry.Rotation.Direction?.Value ?? light.RotationDirection;
+                    light.RotationSynchronizeToBpm = entry.Rotation.SyncToBPM?.Value ?? light.RotationSynchronizeToBpm;
 
-                // Flash settings
-                light.FlashinessDelta = entry.Flashiness.DeltaDeg ?? light.FlashinessDelta;
-                light.FlashinessStart = entry.Flashiness.StartDeg ?? light.FlashinessStart;
-                light.FlashinessSpeed = entry.Flashiness.Speed?.Value ?? light.FlashinessSpeed;
-                light.FlashinessSequenceRaw = entry.Flashiness.Sequence ?? light.FlashinessSequenceRaw;
-                light.FlashinessMultiples = entry.Flashiness.Multiples?.Value ?? light.FlashinessMultiples;
-                light.FlashinessDirection = entry.Flashiness.Direction?.Value ?? light.FlashinessDirection;
-                light.FlashinessSynchronizeToBpm = entry.Flashiness.SyncToBPM?.Value ?? light.FlashinessSynchronizeToBpm;
+                    // Flash settings
+                    light.FlashinessDelta = entry.Flashiness.DeltaDeg ?? light.FlashinessDelta;
+                    light.FlashinessStart = entry.Flashiness.StartDeg ?? light.FlashinessStart;
+                    light.FlashinessSpeed = entry.Flashiness.Speed?.Value ?? light.FlashinessSpeed;
+                    light.FlashinessSequenceRaw = entry.Flashiness.Sequence ?? light.FlashinessSequenceRaw;
+                    light.FlashinessMultiples = entry.Flashiness.Multiples?.Value ?? light.FlashinessMultiples;
+                    light.FlashinessDirection = entry.Flashiness.Direction?.Value ?? light.FlashinessDirection;
+                    light.FlashinessSynchronizeToBpm = entry.Flashiness.SyncToBPM?.Value ?? light.FlashinessSynchronizeToBpm;
+                }
             }
         }
 

--- a/DLSv2/Core/SirenSetting.cs
+++ b/DLSv2/Core/SirenSetting.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Xml.Serialization;
+using Rage;
 
 namespace DLSv2.Core
 {
@@ -70,30 +72,52 @@ namespace DLSv2.Core
 
         [XmlArray("sirens", IsNullable = true)]
         [XmlArrayItem("Item")]
+        // public List<SirenEntry> Sirens
         public SirenEntry[] Sirens
         {
-            get => sirenList.ToArray();
+            get => SirenList.ToArray();
+
             set
             {
                 for (int i = 0; i < value.Length; i++)
                 {
-                    SirenEntry siren = value[i];
-                    int sirenID = siren.ID;
-                    if (sirenID == 0)
-                        siren.ID = (i + 1);
-                    sirenList[siren.ID - 1] = siren;
+                    SirenEntry entry = value[i];
+                    if (entry.sirenIDs == null || entry.sirenIDs.Length == 0)
+                    {
+                        entry.sirenIDs = new int[] { i + 1 };
+                    }
                 }
+                SirenList = value.ToList();
             }
         }
 
         [XmlIgnore]
-        private SirenEntry[] sirenList = new SirenEntry[32];
+        public List<SirenEntry> SirenList = new List<SirenEntry>();
     }
 
     public class SirenEntry
     {
+        public SirenEntry() { }
+
+        public SirenEntry(params int[] IDs) { sirenIDs = IDs; }
+
         [XmlAttribute("id")]
-        public int ID { get; set; }
+        public string IDs
+        {
+            get => string.Join(",", sirenIDs);
+
+            set
+            {
+                if (value == "all")
+                    sirenIDs = Enumerable.Range(1, EmergencyLighting.MaxLights).ToArray();
+
+                else
+                    sirenIDs = value.Split(',').Select(x => int.Parse(x.Trim())).ToArray();
+            }
+        }
+
+        [XmlIgnore]
+        public int[] sirenIDs { get; set; } = new int[] { };
 
         [XmlElement("rotation", IsNullable = true)]
         public LightDetailEntry Rotation { get; set; } = new LightDetailEntry();

--- a/Templates/default.xml
+++ b/Templates/default.xml
@@ -2450,12 +2450,7 @@
 				</Weather>
 			</Triggers>
 			<Sequences>
-				<Item id="1" sequence="11110000111100001111000011110000"/>
-				<Item id="2" sequence="11110000111100001111000011110000"/>
-				<Item id="3" sequence="11110000111100001111000011110000"/>
-				<Item id="4" sequence="11110000111100001111000011110000"/>
-				<Item id="5" sequence="11110000111100001111000011110000"/>
-				<Item id="6" sequence="11110000111100001111000011110000"/>
+				<Item id="1,2,3,4,5,6" sequence="11110000111100001111000011110000"/>
 			</Sequences>
 		</Mode>
 		<Mode name="SlowMoving">
@@ -2463,8 +2458,7 @@
 				<Speed min="0.5" max="20" inclusive="false" />
 			</Triggers>
 			<Sequences>
-				<Item id="3" sequence="10101011111111111111111111111111"/>
-				<Item id="4" sequence="10101011111111111111111111111111"/>
+				<Item id="3,4" sequence="10101011111111111111111111111111"/>
 			</Sequences>
 		</Mode>
 		<Mode name="FastMoving">
@@ -2485,8 +2479,7 @@
 				<VehicleOwner is_player_vehicle="true" />
 			</Requirements>
 			<Sequences>
-				<Item id="7" sequence="11111111111111111111111111111111"/>
-				<Item id="8" sequence="11111111111111111111111111111111"/>
+				<Item id="7,8" sequence="11111111111111111111111111111111"/>
 			</Sequences>
 		</Mode>
 		<Mode name="Stage 3 Yelp">
@@ -2497,8 +2490,7 @@
 				<LightMode name="Stage 3" active="true" />
 			</Requirements>
 			<Sequences>
-				<Item id="leftHeadLight" sequence="10101010101010101010101010101010"/>
-				<Item id="rightHeadLight" sequence="10101010101010101010101010101010"/>
+				<Item id="leftHeadLight,rightHeadLight,1,6" sequence="10101010101010101010101010101010"/>
 			</Sequences>
 		</Mode>
 		<Mode name="Left Door Kill">
@@ -2560,10 +2552,7 @@
 				<Braking status="true" />
 			</Triggers>
 			<Sequences>
-				<Item id="11" sequence="11111111111111111111111111111111"/>
-				<Item id="12" sequence="11111111111111111111111111111111"/>
-				<Item id="13" sequence="11111111111111111111111111111111"/>
-				<Item id="14" sequence="11111111111111111111111111111111"/>
+				<Item id="11,12,13,14" sequence="11111111111111111111111111111111"/>
 			</Sequences>
 		</Mode>
 		<Mode name="Night Time Slow">
@@ -2572,6 +2561,11 @@
 			</Triggers>
 			<SirenSettings>
 				<timeMultiplier value="1" />
+				<sirens>
+					<Item id="all">
+						<intensity value="5" />
+					</Item>
+				</sirens>
 			</SirenSettings>
 		</Mode>
 	</Modes>


### PR DESCRIPTION
Format for either: 

```xml
<Item id="15,16,19,20">
```

Backwards compatible to single IDs, also accepts keyword "all" on siren entries (but not sequencers). 