### PR TITLE
Implemented pattern syncing and desyncing configurations

### DIFF
--- a/DLSv2/Core/DLSModel.cs
+++ b/DLSv2/Core/DLSModel.cs
@@ -16,6 +16,9 @@ namespace DLSv2.Core
         [XmlElement("Audio", IsNullable = true)]
         public AudioSettings AudioSettings = new AudioSettings();
 
+        [XmlElement("PatternSync")]
+        public string SyncGroup;
+
         [XmlArray("Modes")]
         [XmlArrayItem("Mode")]
         public List<Mode> Modes = new List<Mode>();

--- a/DLSv2/Core/DLSModel.cs
+++ b/DLSv2/Core/DLSModel.cs
@@ -19,6 +19,9 @@ namespace DLSv2.Core
         [XmlElement("PatternSync")]
         public string SyncGroup;
 
+        [XmlElement("SpeedDrift")]
+        public float DriftRange = 0f;
+
         [XmlArray("Modes")]
         [XmlArrayItem("Mode")]
         public List<Mode> Modes = new List<Mode>();

--- a/DLSv2/Core/Lights/LightController.cs
+++ b/DLSv2/Core/Lights/LightController.cs
@@ -55,14 +55,12 @@ namespace DLSv2.Core.Lights
             {
                 managedVehicle.LightsOn = false;
                 ModeManager.ApplyModes(managedVehicle, new List<Mode>());
-                managedVehicle.Vehicle.IsSirenOn = false;
                 //AudioController.KillSirens(managedVehicle);
                 return;
             }
 
             // Turns on vehicle siren
             managedVehicle.LightsOn = true;
-            if (!managedVehicle.Vehicle.IsSirenOn) managedVehicle.Vehicle.IsSirenOn = true;
 
             // Sets EL with appropriate modes
             ModeManager.ApplyModes(managedVehicle, modes);

--- a/DLSv2/Core/Lights/ModeManager.cs
+++ b/DLSv2/Core/Lights/ModeManager.cs
@@ -131,6 +131,10 @@ namespace DLSv2.Core.Lights
                 }
             }
 
+            // Adjust time multiplier if a drift is configured
+            float? newTimeMultiplier = SyncManager.GetAdjustedMultiplier(vehicle, eL.TimeMultiplier);
+            if (newTimeMultiplier.HasValue) eL.TimeMultiplier = newTimeMultiplier.Value;
+
             foreach (var extra in extras)
             {
                 if (!vehicle.HasExtra(extra.Key)) continue;

--- a/DLSv2/Core/Lights/SyncManager.cs
+++ b/DLSv2/Core/Lights/SyncManager.cs
@@ -10,8 +10,32 @@ namespace DLSv2.Core.Lights
     internal static class SyncManager
     {
         internal static Dictionary<Model, uint> SyncGroups = new Dictionary<Model, uint>();
+        internal static Dictionary<Model, float> DriftRanges = new Dictionary<Model, float>();
+        internal static Dictionary<Vehicle, float> DriftMultipliers = new Dictionary<Vehicle, float>();
 
-        internal static void AddGroup(Model model, string group)
+        internal static void AddDriftRange(Model model, float range)
+        {
+            if (!DriftRanges.ContainsKey(model) && range != 0)
+            {
+                DriftRanges.Add(model, range);
+            }
+        }
+
+        internal static float? GetAdjustedMultiplier(Vehicle vehicle, float initial)
+        {
+            if (!DriftRanges.ContainsKey(vehicle.Model)) return null;
+
+            if (!DriftMultipliers.TryGetValue(vehicle, out float drift))
+            {
+                float range = Math.Abs(DriftRanges[vehicle.Model]);
+                drift = MathHelper.GetRandomSingle(-range, range);
+                DriftMultipliers.Add(vehicle, drift);
+            }
+
+            return initial * (1 + drift);
+        }
+
+        internal static void AddSyncGroup(Model model, string group)
         {
             if (string.IsNullOrWhiteSpace(group)) return;
             group = group.Trim().ToUpper();

--- a/DLSv2/Core/Lights/SyncManager.cs
+++ b/DLSv2/Core/Lights/SyncManager.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rage;
+
+namespace DLSv2.Core.Lights
+{
+    using Utils;
+
+    internal static class SyncManager
+    {
+        internal static Dictionary<Model, uint> SyncGroups = new Dictionary<Model, uint>();
+
+        internal static void AddGroup(Model model, string group)
+        {
+            if (string.IsNullOrWhiteSpace(group)) return;
+            group = group.Trim().ToUpper();
+            if (!SyncGroups.ContainsKey(group))
+            {
+                SyncGroups.Add(model, Game.GetHashKey(group) % 60000);
+            }
+        }
+
+        internal static void SyncSirens(Vehicle vehicle)
+        {
+            if (SyncGroups.TryGetValue(vehicle.Model, out uint offset))
+            {
+                new SirenInstance(vehicle).SetSirenOnTime(offset);
+            }
+        }
+    }
+}

--- a/DLSv2/Core/ManagedVehicle.cs
+++ b/DLSv2/Core/ManagedVehicle.cs
@@ -79,7 +79,22 @@ namespace DLSv2.Core
         /// <summary>
         /// Lights
         /// </summary>
-        public bool LightsOn { get; set; }
+        public bool LightsOn
+        {
+            get => Vehicle.IsSirenOn;
+            
+            set
+            {
+                if (value)
+                {
+                    SyncManager.SyncSirens(Vehicle);
+                    if (!Vehicle.IsSirenOn) Vehicle.IsSirenOn = true;
+                } else
+                {
+                    Vehicle.IsSirenOn = false;
+                }
+            }
+        }
         public bool InteriorLight { get; set; }
         public VehicleIndicatorLightsStatus IndStatus { get; set; } = VehicleIndicatorLightsStatus.Off;
         public Dictionary<string, (bool Status, int Index)> LightControlGroups = new Dictionary<string, (bool, int)>();

--- a/DLSv2/DLSv2.csproj
+++ b/DLSv2/DLSv2.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Utils\Modkits.cs" />
     <Compile Include="Utils\RoadPosition.cs" />
     <Compile Include="Utils\Settings.cs" />
+    <Compile Include="Utils\SirenInstance.cs" />
     <Compile Include="Utils\VehicleExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DLSv2/DLSv2.csproj
+++ b/DLSv2/DLSv2.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Core\Lights\LightController.cs" />
     <Compile Include="Core\Lights\ModeManager.cs" />
     <Compile Include="Core\Lights\GenericLights.cs" />
+    <Compile Include="Core\Lights\SyncManager.cs" />
     <Compile Include="Core\ManagedVehicle.cs" />
     <Compile Include="Core\SirenApply.cs" />
     <Compile Include="Core\SirenSetting.cs" />

--- a/DLSv2/Utils/Loaders.cs
+++ b/DLSv2/Utils/Loaders.cs
@@ -53,7 +53,10 @@ namespace DLSv2.Utils
                             registeredModels.Add(model);
 
                             // Add V2V Sync Config
-                            SyncManager.AddGroup(model, dlsModel.SyncGroup);
+                            SyncManager.AddSyncGroup(model, dlsModel.SyncGroup);
+
+                            // Add speed multiplier drift
+                            SyncManager.AddDriftRange(model, dlsModel.DriftRange);
 
                             // Adds Light Modes
                             ModeManager.Modes.Add(model, new Dictionary<string, Mode>());

--- a/DLSv2/Utils/Loaders.cs
+++ b/DLSv2/Utils/Loaders.cs
@@ -52,6 +52,9 @@ namespace DLSv2.Utils
                         {
                             registeredModels.Add(model);
 
+                            // Add V2V Sync Config
+                            SyncManager.AddGroup(model, dlsModel.SyncGroup);
+
                             // Adds Light Modes
                             ModeManager.Modes.Add(model, new Dictionary<string, Mode>());
                             foreach (Mode mode in dlsModel.Modes)

--- a/DLSv2/Utils/SirenInstance.cs
+++ b/DLSv2/Utils/SirenInstance.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Rage;
+using Rage.Attributes;
+
+namespace DLSv2.Utils
+{
+    public unsafe struct SirenInstance
+    {
+        [StructLayout(LayoutKind.Explicit)]
+        private struct sirenInstanceData
+        {
+            [FieldOffset(0x000)] public uint sirenOnTime;
+            [FieldOffset(0x004)] public float sirenTimeDelta;
+            [FieldOffset(0x008)] public int lastSirenBeat;
+        };
+
+        private static short sirenDataOffset;
+
+        static SirenInstance()
+        {
+            GetSirenDataOffset();
+        }
+
+        public SirenInstance(Vehicle vehicle)
+        {
+            this.Vehicle = vehicle;
+        }
+
+        public Vehicle Vehicle { get; }
+        private sirenInstanceData* data => *(sirenInstanceData**)(Vehicle.MemoryAddress + sirenDataOffset);
+
+        public uint SirenOnTime => data->sirenOnTime;
+        public float SirenTimeDelta => data->sirenTimeDelta;
+        public int TotalSirenBeats => data->lastSirenBeat;
+        public int CurrentSirenBeat => data->lastSirenBeat % 32;
+        public int GameTimeOffset => TotalSirenBeats < 0 ? 0 : (int)(Math.Round(SirenOnTime + SirenTimeDelta, 0) - Game.GameTime);
+
+        public void SetSirenOnTime(uint gameTime)
+        {
+            if (TotalSirenBeats >= 0)
+                data->sirenOnTime = (uint)(gameTime + GameTimeOffset);
+        }
+
+        public void SetSirenOnTime() => SetSirenOnTime(Game.GameTime);
+
+        private static void GetSirenDataOffset()
+        {
+            IntPtr addr = Game.FindPattern("48 89 B7 ?? ?? ?? ?? 48 8B 0B");
+            if (addr == IntPtr.Zero) throw new Exception("Can't find pattern for the siren data");
+            addr = addr + 3;
+            sirenDataOffset = *(short*)addr;
+        }
+
+#if DEBUG
+        [ConsoleCommand]
+        private static void DebugSirenBeats()
+        {
+            Vehicle v = Game.LocalPlayer.Character.LastVehicle;
+            SirenInstance s = new SirenInstance(v);
+
+            while (v && Game.LocalPlayer.Character.LastVehicle == v)
+            {
+                string info = "";
+                info += $"On Time: {s.SirenOnTime}\n";
+                info += $"Time Delta: {s.SirenTimeDelta}\n";
+                info += $"Total Beats: {s.TotalSirenBeats}\n";
+                info += $"Last Beat: {s.CurrentSirenBeat}\n";
+                info += $"Time Offset: {s.GameTimeOffset}\n";
+                Game.DisplaySubtitle(info, 10);
+                GameFiber.Yield();
+            }
+        }
+
+        [ConsoleCommand(Name = "ResetSirenOnTime")]
+        private static void Command_ResetSirenOnTime()
+        {
+            while (Game.Console.IsOpen) GameFiber.Yield();
+
+            Vehicle v = Game.LocalPlayer.Character.CurrentVehicle;
+            if (!v) return;
+
+            var s = new SirenInstance(v);
+            s.SetSirenOnTime();
+            Game.DisplayNotification($"Reset siren on time to {Game.GameTime}");
+        }
+
+        [ConsoleCommand(Name = "SetSirenOnTime")]
+        private static void Command_SetSirenOnTime(uint time)
+        {
+            while (Game.Console.IsOpen) GameFiber.Yield();
+
+            Vehicle v = Game.LocalPlayer.Character.CurrentVehicle;
+            if (!v) return;
+
+            var s = new SirenInstance(v);
+            s.SetSirenOnTime(time);
+            Game.DisplayNotification($"Reset siren on time to {time}");
+        }
+#endif
+    }
+}


### PR DESCRIPTION
In a DLS VCF (directly under `<Model>`, at the same level as `<Modes>` and `<Audio>`) you can specify the following: 

 - `<PatternSync>sync_name</PatternSync>`: All configs with the same `sync_name` will have the siren timing reset to the same shared value every time the lights are enabled, causing their sequencers to perfectly align. This can be used across different models or even different VCF configs - as long as they have the same name, they will sync. Different sync names will get a different offset, so that configs you want to sync within themselves but not with other configs will be different. 
 - `<SpeedDrift>0.01</SpeedDrift>`: The `TimeMultiplier` for every mode will be adjusted by &plusmn;_n_% for each vehicle spawned with the config. This effectively desyncs vehicles from each other. A value of 0.01 means there will be a random shift of between -1% and +1% to the initial time multiplier. A value of 0.5 means there would be a random shift between -50% and +50% (not recommended as that's very extreme). The shift is multiplied by the existing TimeMultiplier value, not added. So if your initial time multiplier is 5.0 and you have a drift value of 0.01, your multiplier would end up being somewhere between (5 \* 0.99) = 4.95 and (5 \* 1.01) = 5.05. 