### PR TITLE
Add new conditions: traffic light, time delay, random chance

### DIFF
--- a/DLSv2/Conditions/RandomConditions.cs
+++ b/DLSv2/Conditions/RandomConditions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DLSv2.Conditions
+{
+    using Core;
+    using Rage;
+    using System.Xml.Serialization;
+
+    public class RandomCondition : VehicleCondition
+    {
+        private static Dictionary<ManagedVehicle, bool> cachedResults = new Dictionary<ManagedVehicle, bool>();
+
+        [XmlAttribute("chance")]
+        public int PercentChance { get; set; }
+
+        public bool GetRandomResult() => PercentChance >= MathHelper.GetRandomInteger(0, 100);
+
+        protected override bool Evaluate(ManagedVehicle veh)
+        {
+            if (!cachedResults.TryGetValue(veh, out bool result))
+            {
+                result = GetRandomResult();
+                cachedResults.Add(veh, result);
+            }
+
+            return result;
+        }
+    }
+}

--- a/DLSv2/Conditions/VehicleStatusConditions.cs
+++ b/DLSv2/Conditions/VehicleStatusConditions.cs
@@ -162,4 +162,12 @@ namespace DLSv2.Conditions
             return instance.LastDriver == IsPlayerVehicle;
         }
     }
+
+    public class AtTrafficLightCondition : VehicleCondition
+    {
+        [XmlAttribute("stopped_at_light")]
+        public bool IsAtTrafficLight { get; set; }
+
+        protected override bool Evaluate(ManagedVehicle veh) => veh.Vehicle.IsStoppedAtTrafficLights == IsAtTrafficLight;
+    }
 }

--- a/DLSv2/Core/Condition.cs
+++ b/DLSv2/Core/Condition.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xml.Serialization;
 using Rage;
@@ -7,6 +8,15 @@ namespace DLSv2.Core
 {
     public abstract class BaseCondition
     {
+        [XmlAttribute("delay_time")]
+        public int DelayTime { get; set; } = 0;
+
+        [XmlAttribute("max_on_time")]
+        public int MaxOnTime { get; set; } = 0;
+
+        [XmlAttribute("min_on_time")]
+        public int MinOnTime { get; set; } = 0;
+
         public abstract ConditionInstance GetInstance(ManagedVehicle veh);
 
         public bool Update(ManagedVehicle veh) => GetInstance(veh).Update(veh);
@@ -27,11 +37,14 @@ namespace DLSv2.Core
                 Condition = condition;
             }
 
-            private uint lastUpdate;
-            private bool lastState;
+            private uint lastCalcTime;
+            private bool lastCalcResult;
+            private uint lastCalcChangedOnTime;
+            private bool lastExternalState;
+            private uint lastExternalChangedOnTime;
 
-            public bool LastTriggered => lastState;
-            public uint TimeSinceUpdate => Game.GameTime - lastUpdate;
+            public bool LastTriggered => lastCalcResult;
+            public uint TimeSinceUpdate => Game.GameTime - lastCalcTime;
 
             // Event handler delegate for events sent by this condition
             public delegate void TriggerEvent(ConditionInstance sender, BaseCondition condition, bool state);
@@ -42,18 +55,56 @@ namespace DLSv2.Core
 
             public bool Update(ManagedVehicle veh)
             {
-                if (Game.GameTime > lastUpdate + Condition.UpdateWait)
+                if (Game.GameTime > lastCalcTime + Condition.UpdateWait)
                 {
-                    lastUpdate = Game.GameTime;
-                    bool newState = Condition.Evaluate(veh);
-                    if (lastState == newState) return newState;
-                    lastState = newState;
-                    OnInstanceTriggered?.Invoke(this, Condition, newState);
-                    OnAnyTriggered?.Invoke(this, Condition, newState);
-                    return newState;
+                    lastCalcTime = Game.GameTime;
+                    bool newCalcState = Condition.Evaluate(veh);
+
+                    if (newCalcState != lastCalcResult)
+                    {
+                        lastCalcResult = newCalcState;
+                        if (newCalcState) lastCalcChangedOnTime = Game.GameTime;
+                    }
+
+                    uint timeSinceCalcOn = Game.GameTime - lastCalcChangedOnTime;
+                    uint timeSinceExternalOn = Game.GameTime - lastExternalChangedOnTime;
+
+                    bool newExternalState = newCalcState;
+
+                    // if the new calculated state is on, and the actual external state was previously off,
+                    // and the wait time has not been met, leave it off
+                    if (newCalcState && !lastExternalState && Condition.DelayTime > 0 && timeSinceCalcOn < Condition.DelayTime)
+                    {
+                        newExternalState = false;
+                    }
+
+                    // if the new calculated state is on, and the actual external state has been on for more than the max time, turn it off
+                    if (newCalcState && Condition.MaxOnTime > 0 && (timeSinceCalcOn > Condition.MaxOnTime || (lastExternalState && timeSinceExternalOn > Condition.MaxOnTime)))
+                    {
+                        newExternalState = false;
+                    }
+
+                    // if the new calculated state is off, and the previous actual external state was on, 
+                    // and the minimum on time has not yet been reached, leave it on
+                    if (!newCalcState && lastExternalState && Condition.MinOnTime > 0 && timeSinceExternalOn < Condition.MinOnTime)
+                    {
+                        newExternalState = true;
+                    }
+
+                    // If external state has not changed, return current state and do not trigger events
+                    if (newExternalState == lastExternalState) return lastExternalState;
+
+                    // If external state has changed, update saved state and trigger events
+                    lastExternalState = newExternalState;
+                    if (newExternalState) lastExternalChangedOnTime = Game.GameTime;
+
+                    OnInstanceTriggered?.Invoke(this, Condition, newExternalState);
+                    OnAnyTriggered?.Invoke(this, Condition, newExternalState);
+                    
+                    return newExternalState;
                 }
 
-                return lastState;
+                return lastExternalState;
             }
         }
     }

--- a/DLSv2/DLSv2.csproj
+++ b/DLSv2/DLSv2.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Conditions\RandomConditions.cs" />
     <Compile Include="Conditions\RoadConditions.cs" />
     <Compile Include="Conditions\VehicleStatusConditions.cs" />
     <Compile Include="Core\Condition.cs" />


### PR DESCRIPTION
 - Adds `AtTrafficLightCondition` to check if an AI vehicle is waiting at a red traffic light
 - Adds `RandomCondition`, with a chance from 0-100%, evaluated once for each new managed vehicle when it is first detected
 - Adds `delay_time`, `max_on_time`, `min_on_time`, `stay_on_time` to all conditions