### PR TITLE
Added DLS config option to set paint colors in modes

### DIFF
--- a/DLSv2/Core/DLSModel.cs
+++ b/DLSv2/Core/DLSModel.cs
@@ -89,6 +89,10 @@ namespace DLSv2.Core
         [XmlArrayItem("Kit")]
         public List<ModKit> ModKits = new();
 
+        [XmlArray("Paints", IsNullable = true)]
+        [XmlArrayItem("Paint")]
+        public List<PaintJob> PaintJobs = new();
+
         [XmlElement("SirenSettings", IsNullable = true)]
         public SirenSetting SirenSettings = new();
 
@@ -182,6 +186,15 @@ namespace DLSv2.Core
 
         [XmlAttribute("index")]
         public int Index;
+    }
+
+    public class PaintJob
+    {
+        [XmlAttribute("slot")]
+        public int PaintSlot;
+
+        [XmlAttribute("color")]
+        public int ColorCode;
     }
 
     public class SequenceItem

--- a/DLSv2/Core/ManagedVehicle.cs
+++ b/DLSv2/Core/ManagedVehicle.cs
@@ -93,10 +93,11 @@ namespace DLSv2.Core
         /// <summary>
         /// Vehicle Info
         /// </summary>
-        public Vehicle Vehicle { get; set; }
-        public DLSModel dlsModel { get; set; }
-        public uint VehicleHandle { get; set; }
+        public Vehicle Vehicle { get; }
+        public DLSModel dlsModel { get; }
+        public uint VehicleHandle { get; }
         public Dictionary<int, bool> ManagedExtras = new Dictionary<int, bool>(); // Managed Extras - ID, original state
+        public Dictionary<int, int> ManagedPaint = new Dictionary<int, int>(); // Managed Paint Settings - Paint index, original color code
         private bool areLightsOn;
 
         /// <summary>

--- a/DLSv2/EntryPoint.cs
+++ b/DLSv2/EntryPoint.cs
@@ -114,6 +114,10 @@ namespace DLSv2
                         {
                             managedVehicle.Vehicle.SetExtra(extra.Key, extra.Value);
                         }
+                        foreach (var paint in managedVehicle.ManagedPaint)
+                        {
+                            managedVehicle.Vehicle.SetPaint(paint.Key, paint.Value);
+                        }
                         managedVehicle.Vehicle.IndicatorLightsStatus = VehicleIndicatorLightsStatus.Off;
                         managedVehicle.Vehicle.EmergencyLightingOverride = managedVehicle.Vehicle.DefaultEmergencyLighting;
                         managedVehicle.Vehicle.IsSirenSilent = false;

--- a/DLSv2/Utils/DLSExtensions.cs
+++ b/DLSv2/Utils/DLSExtensions.cs
@@ -179,7 +179,7 @@ namespace DLSv2.Utils
                 // Sets vehicle paints
                 foreach (var paint in mode.PaintJobs)
                 {
-                    paints.Add(paint.PaintSlot, paint.ColorCode);
+                    paints[paint.PaintSlot] = paint.ColorCode;
                 }
 
                 // Sets the yield setting

--- a/DLSv2/Utils/VehicleExtensions.cs
+++ b/DLSv2/Utils/VehicleExtensions.cs
@@ -114,5 +114,113 @@ namespace DLSv2.Utils
 
         public static void SetExtra(this Vehicle vehicle, int extra, bool enabled) =>
             NativeFunction.Natives.SetVehicleExtra(vehicle, extra, !enabled);
+
+        public static (int primary, int secondary) GetColors(this Vehicle vehicle)
+        {
+            NativeFunction.Natives.GET_VEHICLE_COLOURS(vehicle, out int primary, out int secondary);
+            return (primary, secondary);
+        }
+
+        public static void SetColors(this Vehicle vehicle, int primaryColorCode, int secondaryColorCode)
+        {
+            NativeFunction.Natives.SET_VEHICLE_COLOURS(vehicle, primaryColorCode, secondaryColorCode);
+        }
+
+        public static void SetPrimaryColor(this Vehicle vehicle, int primaryColorCode)
+        {
+            SetColors(vehicle, primaryColorCode, GetColors(vehicle).secondary);
+        }
+
+        public static void SetSecondaryColor(this Vehicle vehicle, int secondaryColorCode)
+        {
+            SetColors(vehicle, GetColors(vehicle).primary, secondaryColorCode);
+        }
+
+        public static (int pearl, int wheel) GetExtraColors(this Vehicle vehicle)
+        {
+            NativeFunction.Natives.GET_VEHICLE_EXTRA_COLOURS(vehicle, out int pearl, out int wheel);
+            return (pearl, wheel);
+        }
+
+        public static void SetExtraColors(this Vehicle vehicle, int pearlescentColorCode, int wheelColorCode)
+        {
+            NativeFunction.Natives.SET_VEHICLE_EXTRA_COLOURS(vehicle, pearlescentColorCode, wheelColorCode);
+        }
+
+        public static void SetPearlescentColor(this Vehicle vehicle, int pearlescentColorCode)
+        {
+            SetExtraColors(vehicle, pearlescentColorCode, GetExtraColors(vehicle).wheel);
+        }
+
+        public static void SetWheelColor(this Vehicle vehicle, int wheelColorCode)
+        {
+            SetExtraColors(vehicle, GetExtraColors(vehicle).pearl, wheelColorCode);
+        }
+
+        public static int GetColor5(this Vehicle vehicle) => 
+            NativeFunction.Natives.GET_VEHICLE_EXTRA_COLOUR_5<int>(vehicle);
+
+        public static void SetColor5(this Vehicle vehicle, int colorCode)
+        {
+            NativeFunction.Natives.SET_VEHICLE_EXTRA_COLOUR_5(vehicle, colorCode);
+        }
+
+        public static int GetColor6(this Vehicle vehicle) =>
+    NativeFunction.Natives.GET_VEHICLE_EXTRA_COLOUR_6<int>(vehicle);
+
+        public static void SetColor6(this Vehicle vehicle, int colorCode)
+        {
+            NativeFunction.Natives.SET_VEHICLE_EXTRA_COLOUR_6(vehicle, colorCode);
+        }
+
+        public static void SetPaint(this Vehicle vehicle, int paintSlot, int colorCode)
+        {
+            switch (paintSlot)
+            {
+                case 1:
+                    vehicle.SetPrimaryColor(colorCode);
+                    return;
+                case 2:
+                    vehicle.SetSecondaryColor(colorCode);
+                    return;
+                case 3:
+                    vehicle.SetPearlescentColor(colorCode);
+                    return;
+                case 4:
+                    vehicle.SetWheelColor(colorCode);
+                    return;
+                case 6:
+                    vehicle.SetColor5(colorCode);
+                    return;
+                case 7:
+                    vehicle.SetColor6(colorCode);
+                    return;
+                default:
+                    $"Paint slot {paintSlot} is invalid. Must be one of 1, 2, 3, 4, 6, 7.".ToLog(LogLevel.ERROR);
+                    return;
+            }
+        }
+
+        public static int GetPaint(this Vehicle vehicle, int paintSlot)
+        {
+            switch (paintSlot)
+            {
+                case 1:
+                    return vehicle.GetColors().primary;
+                case 2:
+                    return vehicle.GetColors().secondary;
+                case 3:
+                    return vehicle.GetExtraColors().pearl;
+                case 4:
+                    return vehicle.GetExtraColors().wheel;
+                case 6:
+                    return vehicle.GetColor5();
+                case 7:
+                    return vehicle.GetColor6();
+                default:
+                    $"Paint slot {paintSlot} is invalid. Must be one of 1, 2, 3, 4, 6, 7.".ToLog(LogLevel.ERROR);
+                    return -1;
+            }
+        }
     }
 }

--- a/DLSv2/Utils/VehicleExtensions.cs
+++ b/DLSv2/Utils/VehicleExtensions.cs
@@ -157,16 +157,22 @@ namespace DLSv2.Utils
             SetExtraColors(vehicle, GetExtraColors(vehicle).pearl, wheelColorCode);
         }
 
-        public static int GetColor5(this Vehicle vehicle) => 
-            NativeFunction.Natives.GET_VEHICLE_EXTRA_COLOUR_5<int>(vehicle);
+        public static int GetColor5(this Vehicle vehicle)
+        {
+            NativeFunction.Natives.GET_VEHICLE_EXTRA_COLOUR_5<bool>(vehicle, out int color);
+            return color;
+        }
 
         public static void SetColor5(this Vehicle vehicle, int colorCode)
         {
             NativeFunction.Natives.SET_VEHICLE_EXTRA_COLOUR_5(vehicle, colorCode);
         }
 
-        public static int GetColor6(this Vehicle vehicle) =>
-    NativeFunction.Natives.GET_VEHICLE_EXTRA_COLOUR_6<int>(vehicle);
+        public static int GetColor6(this Vehicle vehicle)
+        {
+            NativeFunction.Natives.GET_VEHICLE_EXTRA_COLOUR_6<bool>(vehicle, out int color);
+            return color;
+        }
 
         public static void SetColor6(this Vehicle vehicle, int colorCode)
         {


### PR DESCRIPTION
Example of a lighting mode using a paint setting: 

```xml
<Mode name="Test PAINT:2">
	<Paints>
		<!-- Secondary Color Slot (PAINT:2) -->
		<!-- Hot Pink (paint code 135) -->
		<Paint slot="2" color="135" />
	</Paints>
</Mode>
```

For color codes see https://github.com/DurtyFree/gta-v-data-dumps/blob/master/vehicleColors.json#

Slots available are:

 - `PAINT:1` (primary)
 - `PAINT:2` (secondary)
 - `PAINT:3` (pearlescent)
 - `PAINT:4` (wheel)
 - ~`PAINT:5`~ (not usable)
 - `PAINT:6` (extra trim)
 - `PAINT:7` (extra trim)