### PR TITLE
Added animation support

### DIFF
--- a/DLSv2/Conditions/VehicleConditions.cs
+++ b/DLSv2/Conditions/VehicleConditions.cs
@@ -388,4 +388,15 @@ namespace DLSv2.Conditions
             broken
         }
     }
+
+    public class AnimEventCondition : VehicleCondition
+    {
+        [XmlAttribute("event")]
+        public string EventName { get; set; }
+
+        [XmlAttribute("active")]
+        public bool Active { get; set; } = true;
+
+        protected override bool Evaluate(ManagedVehicle veh) => veh.Vehicle.IsAnimEventActive(EventName) == Active;
+    }
 }

--- a/DLSv2/Core/DLSModel.cs
+++ b/DLSv2/Core/DLSModel.cs
@@ -1,10 +1,12 @@
-﻿using Rage;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Xml.Serialization;
+using System.ComponentModel;
 using System.Linq;
+using Rage;
 
 namespace DLSv2.Core
 {
+    
     using Utils;
 
     [XmlRoot("Model")]
@@ -209,6 +211,26 @@ namespace DLSv2.Core
 
         [XmlAttribute("flags")]
         public int Flags = 0;
+
+        
+        [XmlIgnore]
+        public float? Speed
+        {
+            get => SpeedValueSpecified ? SpeedValue : (float?)null;
+            set
+            {
+                SpeedValueSpecified = value.HasValue;
+                if (value.HasValue) SpeedValue = value.Value;
+                else SpeedValue = 0;
+            }
+        }
+
+        [XmlIgnore]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool SpeedValueSpecified { get; set; }
+        [XmlAttribute("speed")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float SpeedValue { get; set; }
     }
 
     public class SequenceItem

--- a/DLSv2/Core/DLSModel.cs
+++ b/DLSv2/Core/DLSModel.cs
@@ -89,6 +89,9 @@ namespace DLSv2.Core
         [XmlArrayItem("Kit")]
         public List<ModKit> ModKits = new();
 
+        [XmlElement("Animation", IsNullable = true)]
+        public Animation Animation;
+
         [XmlElement("SirenSettings", IsNullable = true)]
         public SirenSetting SirenSettings = new();
 
@@ -182,6 +185,30 @@ namespace DLSv2.Core
 
         [XmlAttribute("index")]
         public int Index;
+    }
+
+    public class Animation
+    {
+        [XmlElement("Dict")]
+        public string AnimDict;
+
+        [XmlElement("Name")]
+        public string AnimName;
+
+        [XmlAttribute("blend")]
+        public float BlendDelta = 4.0f;
+
+        [XmlAttribute("loop")]
+        public bool Loop = true;
+
+        [XmlAttribute("stay_in_last_frame")]
+        public bool StayInLastFrame = true;
+
+        [XmlAttribute("start_at")]
+        public float StartPhase = 0f;
+
+        [XmlAttribute("flags")]
+        public int Flags = 0;
     }
 
     public class SequenceItem

--- a/DLSv2/Core/ManagedVehicle.cs
+++ b/DLSv2/Core/ManagedVehicle.cs
@@ -98,6 +98,7 @@ namespace DLSv2.Core
         public uint VehicleHandle { get; set; }
         public Dictionary<int, bool> ManagedExtras = new Dictionary<int, bool>(); // Managed Extras - ID, original state
         private bool areLightsOn;
+        public Animation ActiveAnim;
 
         /// <summary>
         /// Lights

--- a/DLSv2/Utils/VehicleExtensions.cs
+++ b/DLSv2/Utils/VehicleExtensions.cs
@@ -2,12 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using DLSv2.Memory;
 using Rage;
 using Rage.Native;
 
 namespace DLSv2.Utils
 {
+    using Core;
+
     public static class VehicleExtensions
     {
         public static float GetForwardSpeed(this Vehicle vehicle) => NativeFunction.Natives.GET_ENTITY_SPEED_VECTOR<Vector3>(vehicle, true).Y;
@@ -114,5 +115,29 @@ namespace DLSv2.Utils
 
         public static void SetExtra(this Vehicle vehicle, int extra, bool enabled) =>
             NativeFunction.Natives.SetVehicleExtra(vehicle, extra, !enabled);
+
+        public static bool PlayAnim(this Vehicle vehicle, string animDict, string animName, float blend, bool loop, bool keepLastFrame, float startPos = 0f, int flags = 0) =>
+            NativeFunction.Natives.PLAY_ENTITY_ANIM<bool>(vehicle, animName, animDict, blend, loop, keepLastFrame, false, startPos, flags);
+
+        public static bool LoadAndPlayAnim(this Vehicle vehicle, AnimationDictionary animDict, string animName, float blend, bool loop, bool keepLastFrame, float startPos = 0f, int flags = 0)
+        {
+            if (!animDict.IsLoaded)
+            {
+                if (!NativeFunction.Natives.DOES_ANIM_DICT_EXIST<bool>(animDict.Name)) return false;
+
+                animDict.LoadAndWait();
+            }
+            
+            return PlayAnim(vehicle, animDict.Name, animName, blend, loop, keepLastFrame, startPos, flags);
+        }
+
+        public static bool LoadAndPlayAnim(this Vehicle vehicle, Animation anim) =>
+            LoadAndPlayAnim(vehicle, anim.AnimDict, anim.AnimName, anim.BlendDelta, anim.Loop, anim.StayInLastFrame, anim.StartPhase, anim.Flags);
+
+        public static bool StopAnim(this Vehicle vehicle, string animDict, string animName, float blend = 4f) =>
+            NativeFunction.Natives.STOP_ENTITY_ANIM<bool>(vehicle, animName, animDict, blend);
+
+        public static bool StopAnim(this Vehicle vehicle, Animation anim) =>
+            StopAnim(vehicle, anim.AnimDict, anim.AnimName, anim.BlendDelta);
     }
 }

--- a/DLSv2/Utils/VehicleExtensions.cs
+++ b/DLSv2/Utils/VehicleExtensions.cs
@@ -116,6 +116,9 @@ namespace DLSv2.Utils
         public static void SetExtra(this Vehicle vehicle, int extra, bool enabled) =>
             NativeFunction.Natives.SetVehicleExtra(vehicle, extra, !enabled);
 
+        public static void SetAnimSpeed(this Vehicle vehicle, string animDict, string animName, float speed) =>
+            NativeFunction.Natives.SET_ENTITY_ANIM_SPEED(vehicle, animDict, animName, speed);
+
         public static bool PlayAnim(this Vehicle vehicle, string animDict, string animName, float blend, bool loop, bool keepLastFrame, float startPos = 0f, int flags = 0) =>
             NativeFunction.Natives.PLAY_ENTITY_ANIM<bool>(vehicle, animName, animDict, blend, loop, keepLastFrame, false, startPos, flags);
 
@@ -131,13 +134,23 @@ namespace DLSv2.Utils
             return PlayAnim(vehicle, animDict.Name, animName, blend, loop, keepLastFrame, startPos, flags);
         }
 
-        public static bool LoadAndPlayAnim(this Vehicle vehicle, Animation anim) =>
-            LoadAndPlayAnim(vehicle, anim.AnimDict, anim.AnimName, anim.BlendDelta, anim.Loop, anim.StayInLastFrame, anim.StartPhase, anim.Flags);
+        public static bool LoadAndPlayAnim(this Vehicle vehicle, Animation anim)
+        {
+            bool result = LoadAndPlayAnim(vehicle, anim.AnimDict, anim.AnimName, anim.BlendDelta, anim.Loop, anim.StayInLastFrame, anim.StartPhase, anim.Flags);
+            if (anim.Speed.HasValue) GameFiber.StartNew(() => SetAnimSpeed(vehicle, anim.AnimDict, anim.AnimName, anim.Speed.Value));
+            return result;
+        }
 
         public static bool StopAnim(this Vehicle vehicle, string animDict, string animName, float blend = 4f) =>
             NativeFunction.Natives.STOP_ENTITY_ANIM<bool>(vehicle, animName, animDict, blend);
 
         public static bool StopAnim(this Vehicle vehicle, Animation anim) =>
             StopAnim(vehicle, anim.AnimDict, anim.AnimName, anim.BlendDelta);
+
+        public static bool IsAnimEventActive(this Vehicle vehicle, uint eventHash) =>
+            NativeFunction.Natives.HAS_ANIM_EVENT_FIRED<bool>(vehicle, eventHash);
+
+        public static bool IsAnimEventActive(this Vehicle vehicle, string eventName) =>
+            IsAnimEventActive(vehicle, Game.GetHashKey(eventName));
     }
 }


### PR DESCRIPTION
## Add animations tag in DLS configs

```xml
<Mode>
  <Animation speed="0.25" blend="2.5" loop="true" stay_in_last_frame="true" start_at="0.5" flags="4">
    <Dict>dict_name</Dict>
    <Name>anim_name</Name>
  </Animation>
</Mode>
```

`Dict` and `Name` are required. All other animation attributes are optional. 

 - Speed: Defaults to 1.0, float multiplier of original animation speed
 - Blend: Defaults to 4.0, higher value makes it take longer to blend from the previous position to the first frame of the animation
 - Loop: Defaults to true, repeats animation indefinitely (should almost always be left as true)
 - Stay in last frame: Defaults to true, leaves animation effects applied after animation is stopped
 - Start at: Defaults to 0, float value from 0-1 indicating position within the animation's full length to start at
 - Flags: Defaults to 0, optional animation flags (typically not used)

## Check for custom animation events in trigger/requirement conditions

```xml
<Mode>
  <Triggers>
    <AnimEvent event="event_name" />
  </Triggers>
</Mode>
```

Custom animation event tags can be defined when creating animations. Use the `VisibleToScript:Event` tag channel. Put the custom event name in the configuration. Condition returns true while custom event is active within the animation. 